### PR TITLE
adiciona função para remover duplicatas

### DIFF
--- a/Main.kt
+++ b/Main.kt
@@ -1,5 +1,6 @@
 fun main() {
-    
+    val numeros1 = listOf(10, 9, 8, 9, 7, 6, 5, 5, 4, 3, 2, 1)
+    println("Remoção de duplicatas: " + executar_estrategia(numeros1, ::removerDplicatas))
 }
 
 fun executar_estrategia(lista: List<Int>, estrategia: (List<Int>) -> List<Int>): List<Int> {

--- a/Main.kt
+++ b/Main.kt
@@ -1,6 +1,6 @@
 fun main() {
     val numeros1 = listOf(10, 9, 8, 9, 7, 6, 5, 5, 4, 3, 2, 1)
-    println("Remoção de duplicatas: " + executar_estrategia(numeros1, ::removerDplicatas))
+    println("Remoção de duplicatas: " + executar_estrategia(numeros1, ::removerDuplicatas))
 }
 
 fun executar_estrategia(lista: List<Int>, estrategia: (List<Int>) -> List<Int>): List<Int> {

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# AtividadeParadigmas
+# Função removerDuplicatas
+
+Essa função recebe uma lista de números inteiros e retorna uma nova lista com os elementos duplicados removidos, mantendo a ordem da primeira ocorrência.
+
+## Como funciona
+
+Utiliza o método `distinct()` do Kotlin para eliminar números repetidos.
+
+## Exemplo de uso
+
+```kotlin
+val numeros = listOf(10, 9, 8, 9, 7, 6, 5, 5, 4, 3, 2, 1)
+val resultado = removerDuplicatas(numeros)
+println(resultado) // Output: [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+João Vitor Ribeiro
 # Função removerDuplicatas
 
 Essa função recebe uma lista de números inteiros e retorna uma nova lista com os elementos duplicados removidos, mantendo a ordem da primeira ocorrência.

--- a/estrategias/remover_duplicatas.kt
+++ b/estrategias/remover_duplicatas.kt
@@ -1,0 +1,3 @@
+fun removerDuplicatas(lista: List<Int>): List<Int> {
+    return lista.distinct()
+}

--- a/estrategias/remover_duplicatas.kt
+++ b/estrategias/remover_duplicatas.kt
@@ -1,3 +1,9 @@
+/**
+ * Remove elementos duplicados de uma lista de inteiros.
+ *
+ * @param lista Lista de números inteiros possivelmente com duplicatas.
+ * @return Nova lista contendo apenas os elementos únicos, mantendo a ordem original.
+ */
 fun removerDuplicatas(lista: List<Int>): List<Int> {
     return lista.distinct()
 }


### PR DESCRIPTION
feat: adiciona função removerDuplicatas para eliminar duplicatas na lista

Implementa a função removerDuplicatas que recebe uma lista de inteiros e retorna uma nova lista sem elementos duplicados, mantendo a ordem original dos números.

Exemplo de uso:

Input: listOf(10, 9, 8, 9, 7, 6, 5, 5, 4, 3, 2, 1)
Output: [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]

A função será usada como uma estratégia passada para executar_estrategia.